### PR TITLE
PySide also has this parameter requirement

### DIFF
--- a/qtpydocking/eliding_label.py
+++ b/qtpydocking/eliding_label.py
@@ -2,7 +2,7 @@ from qtpy.QtCore import QSize, Qt, Signal
 from qtpy.QtGui import QMouseEvent, QResizeEvent
 from qtpy.QtWidgets import QLabel, QWidget
 
-from .util import PYSIDE2
+from .util import PYSIDE, PYSIDE2
 
 
 class ElidingLabelPrivate:
@@ -65,7 +65,7 @@ class ElidingLabel(QLabel):
         parent : QWidget
         flags : Qt.WindowFlags
         '''
-        if PYSIDE2:
+        if PYSIDE or PYSIDE2:
             kwarg = {'f': flags}
         else:
             kwarg = {'flags': flags}


### PR DESCRIPTION
Just a quick fix. I discovered that a parameter for `PySide` was also different than the one being used earlier. Now it should match all 4 API variants.